### PR TITLE
Fix: update for recent Zephyr include path change

### DIFF
--- a/zephyr/platform/deca_port.c
+++ b/zephyr/platform/deca_port.c
@@ -1,4 +1,4 @@
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #include "deca_interface.h"
 

--- a/zephyr/platform/dw3000_hw.c
+++ b/zephyr/platform/dw3000_hw.c
@@ -1,6 +1,6 @@
-#include <device.h>
-#include <drivers/gpio.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 
 #include "deca_device_api.h"

--- a/zephyr/platform/dw3000_spi.c
+++ b/zephyr/platform/dw3000_spi.c
@@ -4,9 +4,9 @@
  * Copyright 2021 (c) Callender-Consulting LLC.
  */
 
-#include <device.h>
-#include <drivers/spi.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 
 #include "dw3000_spi.h"


### PR DESCRIPTION
This is the suggested fix for #2. Header paths have been updated to fix file inclusion errors due to Zephyr removing support for header inclusion without the `zephyr/` path.