### PR TITLE
created single dw3000.h header file to include from application

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -2,3 +2,5 @@
 
 add_subdirectory_ifdef(CONFIG_DW3000 dwt_uwb_driver)
 add_subdirectory_ifdef(CONFIG_DW3000 platform)
+
+zephyr_include_directories_ifdef(CONFIG_DW3000 include)

--- a/zephyr/dwt_uwb_driver/CMakeLists.txt
+++ b/zephyr/dwt_uwb_driver/CMakeLists.txt
@@ -10,7 +10,5 @@ endif()
 # -Wl,--whole-archive flag (keep all symbols)
 zephyr_library_import(dwtlib ${CMAKE_CURRENT_SOURCE_DIR}/lib/${DWTLIBNAME})
 
-zephyr_include_directories(inc)
-
 # the library needs a custom linker script
 zephyr_linker_sources(SECTIONS custom-sections.ld)

--- a/zephyr/include/dw3000.h
+++ b/zephyr/include/dw3000.h
@@ -1,0 +1,11 @@
+#ifndef DW3000_DW3000_H_
+#define DW3000_DW3000_H_
+
+#include <../dwt_uwb_driver/inc/deca_version.h>
+#include <../dwt_uwb_driver/inc/deca_interface.h>
+
+#include <../platform/dw3000_probe_interface.h>
+#include <../platform/dw3000_hw.h>
+#include <../platform/dw3000_spi.h>
+
+#endif // DW3000_DW3000_H_

--- a/zephyr/platform/CMakeLists.txt
+++ b/zephyr/platform/CMakeLists.txt
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
-zephyr_library_sources(dw3000_hw.c dw3000_spi.c deca_port.c)
-zephyr_include_directories(.)
+zephyr_library_sources(dw3000_hw.c dw3000_spi.c dw3000_port.c)

--- a/zephyr/platform/dw3000_hw.c
+++ b/zephyr/platform/dw3000_hw.c
@@ -3,7 +3,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 
-#include "deca_device_api.h"
+#include "../dwt_uwb_driver/inc/deca_device_api.h"
 #include "dw3000_hw.h"
 #include "dw3000_spi.h"
 

--- a/zephyr/platform/dw3000_port.c
+++ b/zephyr/platform/dw3000_port.c
@@ -1,6 +1,6 @@
 #include <zephyr/kernel.h>
 
-#include "deca_interface.h"
+#include "../dwt_uwb_driver/inc/deca_interface.h"
 
 #include "dw3000_hw.h"
 #include "dw3000_spi.h"

--- a/zephyr/platform/dw3000_probe_interface.h
+++ b/zephyr/platform/dw3000_probe_interface.h
@@ -13,7 +13,7 @@
 #ifndef DECA_PROBE_INTERFACE_H
 #define DECA_PROBE_INTERFACE_H
 
-#include "deca_device_api.h"
+#include "../dwt_uwb_driver/inc/deca_types.h"
 
 extern const struct dwt_probe_s dw3000_probe_interf;
 


### PR DESCRIPTION
Hey, thanks for creating the zephyr module!  

I just want to leave this here since I had quite some difficulty with the different include files and naming schemes. At first I did not realize what is needed for using the driver and what exists only for the examples etc.

The internal include path are now relative and not done via CMakeFiles, so if the libarary is included in an application project, there is only one inlcude path to the CMake project with one header file `dw3000.h`. That makes the usage in the application much clearer IMO.

I have also renamed `deca_port.c => dw3000_port.c} (94%)` and `rename zephyr/platform/{deca_probe_interface.h => dw3000_probe_interface.h` since all Decawave library files had "deca" as a prefix and the platform files had dw3000 files.

I do not expect this to merge, since I think the intention was to keep it as close as possible to the original driver and those examples, but for those using the library only without the examples this would probably be more handsome. I am not experienced with CMake Projects, so if am wrong in doing so please tell me.