### PR TITLE
Support for newer Zehpyr kernel versions and nRF5340 SoC

### DIFF
--- a/zephyr/dwt_uwb_driver/CMakeLists.txt
+++ b/zephyr/dwt_uwb_driver/CMakeLists.txt
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_FPU)
-    set(DWTLIBNAME libdwt_uwb_driver-m4-hfp-6.0.7.a)
+    if(CONFIG_SOC_SERIES_NRF53X)
+        set(DWTLIBNAME libdwt_uwb_driver-m33-hfp-6.0.7.a)
+    else()
+        set(DWTLIBNAME libdwt_uwb_driver-m4-hfp-6.0.7.a)
+    endif()
 else()
-    set(DWTLIBNAME libdwt_uwb_driver-m4-sfp-6.0.7.a)
+    if(CONFIG_SOC_SERIES_NRF53X)
+        set(DWTLIBNAME libdwt_uwb_driver-m33-sfp-6.0.7.a)
+    else()
+        set(DWTLIBNAME libdwt_uwb_driver-m4-sfp-6.0.7.a)
+    endif()
 endif()
 
 # use zephyr_library_import in order to get it linked with the

--- a/zephyr/platform/dw3000_spi.c
+++ b/zephyr/platform/dw3000_spi.c
@@ -46,7 +46,7 @@ int dw3000_spi_init(void)
 	spi_cfgs[1].frequency = 8000000;
 
 	/* High SPI clock speed: increase for boards which support higher speeds */
-#if CONFIG_SOC_NRF52833 || CONFIG_SOC_NRF52840
+#if CONFIG_SOC_NRF52833 || CONFIG_SOC_NRF52840 || CONFIG_SOC_NRF5340_CPUAPP_QKAA
 #if CONFIG_SHIELD_QORVO_DWS3000
 	/* Due to the wiring of the Nordic Development Boards and the DWS3000
 	 * Arduino shield it is not possible to use more than 16MHz */

--- a/zephyr/platform/dw3000_spi.c
+++ b/zephyr/platform/dw3000_spi.c
@@ -46,7 +46,7 @@ int dw3000_spi_init(void)
 	spi_cfgs[1].frequency = 8000000;
 
 	/* High SPI clock speed: increase for boards which support higher speeds */
-#if CONFIG_SOC_NRF52833 || CONFIG_SOC_NRF52840 || CONFIG_SOC_NRF5340_CPUAPP_QKAA
+#if CONFIG_SOC_NRF52833 || CONFIG_SOC_NRF52840 || CONFIG_SOC_NRF5340_CPUAPP
 #if CONFIG_SHIELD_QORVO_DWS3000
 	/* Due to the wiring of the Nordic Development Boards and the DWS3000
 	 * Arduino shield it is not possible to use more than 16MHz */


### PR DESCRIPTION
Hi,

I wanted to compile the project with the newest nRF Connect SDK (v2.6.0) with no success.

It turned out, that SPI related function SPI_CS_CONTROL_PTR_DT is deprecated in newer zephyr versions and is replaced with SPI_CS_CONTROL_INIT.

I added the preprocessor directives that choose the appropriate code depending on the used Zephyr kernel version.

Edit: I have also added the support for the nRF5340 SoC (based on Cortex-M33).

Best regards,
Vito