### PR TITLE
remove deprecated label from devicetree

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Then you only need to add a `decawave,dw3000` compatible device to your .dts, e.
 
 	dw3000@0 {
 		compatible = "decawave,dw3000";
-		label = "DW3000";
 		spi-max-frequency = <1000000>;
 		reg = <0>;
 		reset-gpios = <&gpio0 9 GPIO_ACTIVE_LOW>;

--- a/boards/shields/qorvo_dws3000/qorvo_dws3000.overlay
+++ b/boards/shields/qorvo_dws3000/qorvo_dws3000.overlay
@@ -10,7 +10,6 @@
 
     dws3000@0 {
         compatible = "decawave,dw3000";
-        label = "DWS3000";
         spi-max-frequency = <1000000>;
         reg = <0>;
         wakeup-gpios  = <&arduino_header 15 GPIO_ACTIVE_HIGH>; /* D9 */

--- a/platform/dw3000_spi.c
+++ b/platform/dw3000_spi.c
@@ -63,7 +63,7 @@ int dw3000_spi_init(void)
 		LOG_ERR("DW3000 SPI binding failed");
 		return -1;
 	} else {
-		LOG_INF("DW3000 on %s (max %dMHz)", DT_PROP(DW_INST, label),
+		LOG_INF("DW3000 (max %dMHz)",
 				spi_cfgs[1].frequency / 1000000);
 	}
 


### PR DESCRIPTION
apparently some(but not all?) devicetree labels got deprecated, which
causes build warnings or failures

```
'label' is marked as deprecated in 'properties:' in $project/modules/lib/zephyr-dw3000-decadriver/dts/bindings/decawave,dw3000/decawave,dw3
000.yaml for node /soc/spi@4002f000/dwm3000@0.
```
It was only used in a log statement, so this PR removes it
