### PR TITLE
Only define zephyr lib if enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
-add_subdirectory_ifdef(CONFIG_DW3000 platform)
+if(CONFIG_DW3000)
+add_subdirectory(platform)
 
 zephyr_library()
 
-zephyr_library_sources_ifdef(CONFIG_DW3000
+zephyr_library_sources(
     dwt_uwb_driver/deca_interface.c
     dwt_uwb_driver/deca_rsl.c
     dwt_uwb_driver/lib/qmath/src/qmath.c
@@ -15,3 +16,5 @@ zephyr_library_sources_ifdef(CONFIG_DW3000_CHIP_DW3720 dwt_uwb_driver/dw3720/dw3
 
 zephyr_include_directories(dwt_uwb_driver)
 zephyr_include_directories(dwt_uwb_driver/lib/qmath/include)
+
+endif(CONFIG_DW3000)


### PR DESCRIPTION
Prevent cmake warnings from a zephyr lib with no sources

if you include this in your west workspace but don't enable CONFIG_DW3000, you get the following cmake warning:
```
CMake Warning at $westWorkspace/zephyr/CMakeLists.txt:862 (message):
  No SOURCES given to Zephyr library:
  ..__modules__lib__zephyr-dw3000-decadriver

  Excluding target from build.
```
so this just follows the randomly chosen example of zephyr/modules/thrif/CMakeLists.txt

