### PR TITLE
[MOD] Changing DW3000 port to be compatible with nRF SDK v2.8.0

### DIFF
--- a/zephyr/platform/deca_port.c
+++ b/zephyr/platform/deca_port.c
@@ -1,4 +1,4 @@
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #include "deca_interface.h"
 

--- a/zephyr/platform/dw3000_hw.c
+++ b/zephyr/platform/dw3000_hw.c
@@ -1,6 +1,6 @@
-#include <device.h>
-#include <drivers/gpio.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 
 #include "deca_device_api.h"

--- a/zephyr/platform/dw3000_spi.c
+++ b/zephyr/platform/dw3000_spi.c
@@ -4,9 +4,9 @@
  * Copyright 2021 (c) Callender-Consulting LLC.
  */
 
-#include <device.h>
-#include <drivers/spi.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log.h>
 #include <zephyr/kernel.h>
 
 #include "dw3000_spi.h"
@@ -21,7 +21,7 @@ LOG_MODULE_DECLARE(dw3000, CONFIG_DW3000_LOG_LEVEL);
 #define DW_SPI	DT_PARENT(DT_INST(0, decawave_dw3000))
 
 static const struct device* spi;
-static struct spi_cs_control* cs_ctrl = SPI_CS_CONTROL_PTR_DT(DW_INST, 0);
+static struct spi_cs_control cs_ctrl = SPI_CS_CONTROL_INIT(DW_INST, 0);
 static struct spi_config spi_cfgs[2] = {0}; // configs for slow and fast
 static struct spi_config* spi_cfg;
 
@@ -173,7 +173,7 @@ int dw3000_spi_read(uint16_t headerLength, uint8_t* headerBuffer,
 
 void dw3000_spi_wakeup()
 {
-	gpio_pin_set_dt(&cs_ctrl->gpio, 1);
+	gpio_pin_set_dt(&cs_ctrl.gpio, 1);
 	k_sleep(K_USEC(500));
-	gpio_pin_set_dt(&cs_ctrl->gpio, 0);
+	gpio_pin_set_dt(&cs_ctrl.gpio, 0);
 }


### PR DESCRIPTION
This commit changes the port files in order to use the newer style of include files (e.g. `<zephyr/device.h>` instead of `<device.h>`) and to use `SPI_CS_CONTROL_INIT` instead of `SPI_CS_CONTROL_PTR_DT`.

This is based on the "old" Qorvo SDK, thus needs probably to go on a separate branch if merged.