### PR TITLE
Fix build errors for DW3720

### DIFF
--- a/dwt_uwb_driver/dw3720/dw3720_device.c
+++ b/dwt_uwb_driver/dw3720/dw3720_device.c
@@ -360,7 +360,7 @@ void ull_dis_otp_ips(dwchip_t *dw, int mode);
 void ull_setrxtimeout(dwchip_t *dw, uint32_t on_time);
 void ull_setpreambledetecttimeout(dwchip_t *dw, uint16_t timeout);
 static void ull_aon_write(dwchip_t *dw, uint16_t aon_address, uint8_t aon_write_data);
-static uint8_t ull_aon_read(dwchip_t *dw, uint16_t aon_address);
+uint8_t ull_aon_read(dwchip_t *dw, uint16_t aon_address);
 float ull_convertrawtemperature(dwchip_t *dw, uint8_t raw_temp);
 uint16_t ull_readtempvbat(dwchip_t *dw);
 static uint16_t ull_readsar(dwchip_t *dw, uint8_t input_mux, uint8_t attn);

--- a/platform/deca_compat.c
+++ b/platform/deca_compat.c
@@ -20,7 +20,7 @@
 
 #if CONFIG_DW3000_CHIP_DW3720
 #include "dw3720/dw3720_deca_regs.h"
-#include "dw3720/df3720_deca_vals.h"
+#include "dw3720/dw3720_deca_vals.h"
 #elif CONFIG_DW3000_CHIP_DW3000
 #include "dw3000/dw3000_deca_regs.h"
 #include "dw3000/dw3000_deca_vals.h"


### PR DESCRIPTION
I discovered a couple of issues that prevented the driver from building when configured for DW3720.  These minor changes allowed the build to succeed, and I was able to successfully use the driver with the QM33 after these changes.