### PR TITLE
Allow custom max SPI frequency for all SOCs

### DIFF
--- a/platform/dw3000_spi.c
+++ b/platform/dw3000_spi.c
@@ -43,18 +43,14 @@ int dw3000_spi_init(void)
 	/* Slow SPI clock speed: 2MHz */
 	spi_cfgs[0].frequency = 2000000;
 
-	/* High SPI clock speed: assume 8MHz for all boards */
-	spi_cfgs[1].frequency = 8000000;
-
 	/* High SPI clock speed: increase for boards which support higher speeds */
-#if CONFIG_SOC_NRF52833 || CONFIG_SOC_NRF52840 || CONFIG_SOC_NRF5340_CPUAPP
-#if CONFIG_SHIELD_QORVO_DWS3000
+#if (CONFIG_SOC_NRF52833 || CONFIG_SOC_NRF52840 || CONFIG_SOC_NRF5340_CPUAPP) \
+    && CONFIG_SHIELD_QORVO_DWS3000 && (CONFIG_DW3000_SPI_MAX_MHZ > 16)
 	/* Due to the wiring of the Nordic Development Boards and the DWS3000
 	 * Arduino shield it is not possible to use more than 16MHz */
 	spi_cfgs[1].frequency = 16000000;
 #else
 	spi_cfgs[1].frequency = CONFIG_DW3000_SPI_MAX_MHZ * 1000000;
-#endif
 #endif
 
 	spi_cfg = &spi_cfgs[0];


### PR DESCRIPTION
This change corrects an issue where CONFIG_DW3000_SPI_MAX_MHZ was only applied for SOCs nRF52833, nRF52840, and nRF5340.  It now applies to all SOCs.

The 8 MHz default for other SOCs has been removed, since the Kconfig value now always applies.

I tested this with an ST nucleo_h563zi board, and verified that the configuration now works as expected.