### PR TITLE
Fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,31 @@ CONFIG_GPIO=y
 This is a minimal code fragment to check the basic functionality (reading the
 device ID).
 
-```
-dw3000_hw_init();
-dw3000_hw_reset();
-uint32_t dev_id = dwt_readdevid();
-LOG_INF("DEVID %x", devid);
+```c
+#include <zephyr/kernel.h>
+#include <zephyr/types.h>
+
+#include <deca_device_api.h>
+#include <deca_probe_interface.h>
+#include <dw3000_hw.h>
+
+#include <stdio.h>
+
+int main() {
+    uint32_t dev_id;
+
+    dw3000_hw_init();
+    dw3000_hw_reset();
+
+    k_sleep(K_MSEC(2000));
+
+    dwt_probe((struct dwt_probe_s *)&dw3000_probe_interf);
+
+    dev_id = dwt_readdevid();
+    printf("Device ID: %x\n", dev_id);
+
+    return 0;
+}
 ```
 
 ## Next steps


### PR DESCRIPTION
Fix the usage example in the README so it is a complete example.

This example was tested with a [DW3001CDK](https://www.qorvo.com/products/p/DWM3001CDK) using the `decawave_dwm3001cdk` board defined in Zephyr.

The `prj.conf` file contained...

```
CONFIG_GPIO=y
CONFIG_SPI=y
CONFIG_DW3000=y
CONFIG_DW3000_CHIP_DW3000=y
```

The `decawave_dwm3001cdk.overlay` file contained...

```
&spi3 {
    dw3000: dw3000@0 {
        compatible = "decawave,dw3000";
	    status = "okay";
        spi-max-frequency = <16000000>;
        reg = <0>;
        reset-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
        irq-gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
    };
};
```

The `main.c` file contained...

```c
#include <zephyr/kernel.h>
#include <zephyr/types.h>

#include <deca_device_api.h>
#include <deca_probe_interface.h>
#include <dw3000_hw.h>

#include <stdio.h>

int main() {
    uint32_t dev_id;

    dw3000_hw_init();
    dw3000_hw_reset();

    k_sleep(K_MSEC(2000));

    dwt_probe((struct dwt_probe_s *)&dw3000_probe_interf);

    dev_id = dwt_readdevid();
    printf("Device ID: %x\n", dev_id);

    return 0;
}
```

This fixes #28.