### PR TITLE
Add extern C guards to headers for C++ compatibility

### DIFF
--- a/platform/deca_probe_interface.h
+++ b/platform/deca_probe_interface.h
@@ -15,6 +15,15 @@
 
 #include "deca_device_api.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 extern const struct dwt_probe_s dw3000_probe_interf;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/dw3000_hw.h
+++ b/platform/dw3000_hw.h
@@ -3,6 +3,11 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 int dw3000_hw_init(void);
 int dw3000_hw_init_interrupt(void);
 void dw3000_hw_fini(void);
@@ -12,5 +17,9 @@ void dw3000_hw_wakeup_pin_low(void);
 void dw3000_hw_interrupt_enable(void);
 void dw3000_hw_interrupt_disable(void);
 bool dw3000_hw_interrupt_is_enabled(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/platform/dw3000_spi.h
+++ b/platform/dw3000_spi.h
@@ -7,6 +7,11 @@
 #define CONFIG_DW3000_SPI_TRACE 0
 #endif
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 int dw3000_spi_init(void);
 void dw3000_spi_fini(void);
 void dw3000_spi_wakeup(void);
@@ -21,5 +26,9 @@ int32_t dw3000_spi_write_crc(uint16_t headerLength, const uint8_t* headerBuffer,
 							 uint8_t crc8);
 
 void dw3000_spi_trace_output(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Some header files in this repo are not compatible with C++ because they lack the extern "C" guards.
This can cause linkage errors when these headers are included in C++ projects.

I suggest adding the following pattern to all public header files:

#ifdef __cplusplus
extern "C" {
#endif

// ... existing content ...

#ifdef __cplusplus
}
#endif