### PR TITLE
Improve DW3000 work queue handling, add MAC 802.15.4 library, and shared platform functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ zephyr_library_sources(
     dwt_uwb_driver/deca_interface.c
     dwt_uwb_driver/deca_rsl.c
     dwt_uwb_driver/lib/qmath/src/qmath.c
+    MAC_802_15_4/mac_802_15_4.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_DW3000_CHIP_DW3000 dwt_uwb_driver/dw3000/dw3000_device.c)
@@ -23,5 +24,6 @@ zephyr_library_sources_ifdef(CONFIG_DW3000_CHIP_DW3720 dwt_uwb_driver/dw3720/dw3
 zephyr_include_directories(platform)
 zephyr_include_directories(dwt_uwb_driver)
 zephyr_include_directories(dwt_uwb_driver/lib/qmath/include)
+zephyr_include_directories(MAC_802_15_4)
 
 endif(CONFIG_DW3000)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ zephyr_library_sources(
     platform/dw3000_spi.c
     platform/dw3000_spi_trace.c
     platform/deca_compat.c
+    platform/config_options.c
+    platform/shared_functions.c
     dwt_uwb_driver/deca_interface.c
     dwt_uwb_driver/deca_rsl.c
     dwt_uwb_driver/lib/qmath/src/qmath.c

--- a/MAC_802_15_4/mac_802_15_4.c
+++ b/MAC_802_15_4/mac_802_15_4.c
@@ -1,0 +1,289 @@
+/*! ----------------------------------------------------------------------------
+ * @file    mac_802_15_4.c
+ * @brief   Functions that handle 802.15.4 frame
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+#include <deca_device_api.h>
+#include <mac_802_15_4.h>
+#include <string.h>
+
+dwt_mic_size_e dwt_mic_size_from_bytes(uint8_t mic_size_in_bytes);
+
+/*Set the pan id src + dst and src and dst addresses*/
+void mac_frame_set_pan_ids_and_addresses_802_15_4(
+    mac_frame_802_15_4_format_t *mac_frame_ptr, uint16_t dest_pan_id, uint64_t dest_addr /*,uint16_t src_pan_id*/, uint64_t src_addr)
+{
+    /*Doing this kind of assignment to support big/little Endian*/
+    uint8_t cnt;
+
+    for (cnt = 0; cnt < sizeof(uint64_t); cnt++) // EXTENDED_ADDR
+    {
+        MAC_FRAME_SRC_ADDR_802_15_4(mac_frame_ptr, cnt) = (uint8_t)(src_addr);
+        src_addr >>= 8;
+        MAC_FRAME_DEST_ADDR_ID_802_15_4(mac_frame_ptr, cnt) = (uint8_t)(dest_addr);
+        dest_addr >>= 8;
+    }
+
+    MAC_FRAME_DEST_PAN_ID_802_15_4(mac_frame_ptr, 0) = (uint8_t)dest_pan_id;
+    MAC_FRAME_DEST_PAN_ID_802_15_4(mac_frame_ptr, 1) = (uint8_t)(dest_pan_id >> 8);
+
+    // SRC_PAN_ID_802_15_4(0)=(uint8_t)src_pan_id;
+    // SRC_PAN_ID_802_15_4(1)=(uint8_t)(src_pan_id>>8);
+}
+
+/*Set the first 2 bytes of the MAC frame - Frame control*/
+void mac_frame_init_mac_frame_ctrl(mac_frame_802_15_4_format_t *mac_frame_ptr)
+{
+    /*
+     * Frame control[0]= Data, protected, no more data, no ACK, PEND ID for dest (no for source)
+     * Frame control[1]=Has seq num, no IE, dest addr extended, frame ver 2 (IEEE Std 802.15.4), source extended
+     */
+    MAC_FRAME_FRAME_CTRL_802_15_4(mac_frame_ptr, 0)
+        = (MAC_FRAME_TYPE_802_15_4_DATA << MAC_FRAME_TYPE_SHIFT_VALUE) | (MAC_SEC_EN_PROTECTED << MAC_FRAME_SECURITY_ENABLED_SHIFT_VALUE)
+          | (MAC_PEND_FRAME_NO_MORE_DATA << MAC_FRAME_FRAME_PENDING_SHIFT_VALUE) | (MAC_AR_NO_ACK << MAC_FRAME_AR_SHIFT_VALUE)
+          | (MAC_PEND_ID_COMPRESS_DEST_EXIST_SOURCE_NOT << MAC_FRAME_PAN_ID_SHIFT_VALUE);
+    MAC_FRAME_FRAME_CTRL_802_15_4(mac_frame_ptr, 1)
+        = (MAC_SEQ_NUM_SUPP_PRESENT << MAC_FRAME_SEQ_NUM_SUPPRESS_SHIFT_VALUE) | (MAC_SEQ_NUM_SUPP_PRESENT << MAC_FRAME_IE_PRESET_SHIFT_VALUE)
+          | (MAC_DEST_ADDR_MODE_EXT_ADDR_64_BITS << MAC_FRAME_DEST_ADDR_MODE_SHIFT_VALUE) | (DATA_FRAME_VERSION << MAC_FRAME_FRAME_VER_SHIFT_VALUE)
+          | (MAC_SRC_ADDR_MODE_EXT_ADDR_64_BITS << MAC_FRAME_SRC_ADDR_MODE_SHIFT_VALUE);
+}
+
+/* This function updates the MAC frame sequence number */
+void mac_frame_update_sequence_number(mac_frame_802_15_4_format_t *mac_frame_ptr, uint8_t seq_num)
+{
+    MAC_FRAME_SEQ_NUM_802_15_4(mac_frame_ptr) = seq_num;
+}
+
+/* Set the security control in the Auxiliary security header */
+/* Security control -  Security level MIC 16(data conf OFF, data Auth Yes), key determine from key index, has frame cnt, frame cnt gen nonce */
+void mac_frame_set_AUX_security_control(mac_frame_802_15_4_format_t *mac_frame_ptr)
+{
+    MAC_FRAME_AUX_SECURITY_CTRL_802_15_4(mac_frame_ptr)
+        = (AUX_SEC_LEVEL_DATA_CONF_ON_MIC_16 << AUX_SECURITY_LEVEL_SHIFT_VALUE) | (AUX_KEY_IDEN_MODE_KEY_INDEX << AUX_KEY_IDENTIFIER_MODE_SHIFT_VALUE)
+          | (AUX_FRAME_CNT_SUPPRESS_OFF << AUX_FRAME_CNT_SUPPRESSION_SHIFT_VALUE) | (AUX_ASN_IN_NOUNCE_FRAME_CNT_GEN_NONCE << AUX_ASN_IN_NONCE);
+}
+
+/* Set the key identifier value, in our case it is one byte - key index */
+void mac_frame_set_AUX_key_identifier(mac_frame_802_15_4_format_t *mac_frame_ptr, uint8_t key_index)
+{
+    MAC_FRAME_AUX_KEY_IDENTIFY_802_15_4(mac_frame_ptr) = key_index; /*First keys set*/
+}
+
+/* Update the frame counter in the MAC frame - AUX security - Frame counter */
+void mac_frame_update_aux_frame_cnt(mac_frame_802_15_4_format_t *mac_frame_802_15_4_format_ptr, uint32_t frame_cnt)
+{
+    uint8_t cnt;
+
+    for (cnt = 0; cnt < AUX_FRAME_CNT_SIZE; cnt++)
+    {
+        MAC_FRAME_AUX_FRAME_CNT_802_15_4(mac_frame_802_15_4_format_ptr, cnt) = (uint8_t)(frame_cnt);
+        frame_cnt >>= 8;
+    }
+}
+
+/* Get the key identifier value, in our case it is one byte - key index */
+uint8_t mac_frame_get_AUX_key_identifier(mac_frame_802_15_4_format_t *mac_frame_ptr)
+{
+    return MAC_FRAME_AUX_KEY_IDENTIFY_802_15_4(mac_frame_ptr);
+}
+
+/* Get the frame counter in the MAC frame - AUX security - Frame counter */
+uint32_t mac_frame_get_aux_frame_cnt(mac_frame_802_15_4_format_t *mac_frame_ptr)
+{
+    int8_t cnt;
+    uint32_t frame_cnt = 0;
+
+    for (cnt = 0; cnt < AUX_FRAME_CNT_SIZE; cnt++)
+    {
+        frame_cnt |= (uint32_t)MAC_FRAME_AUX_FRAME_CNT_802_15_4(mac_frame_ptr, cnt) << (cnt * 8);
+    }
+    return frame_cnt;
+}
+
+/* This function will fill the buffer with the nonce-IV values.
+ * In SS-TWR AES example as specified by IEEE802.15.4 the nonce is of 13-bytes and is made up of Source Address (8), Frame Counter (4) and Nonce Security Level
+ * (1)
+ *
+ * */
+void mac_frame_get_nonce(mac_frame_802_15_4_format_t *mac_frame_ptr, uint8_t *aes_iv)
+{
+    // Copy Source Address (8)
+    memcpy(&aes_iv[0], MAC_FRAME_SRC_ADDR_PTR_802_15_4(mac_frame_ptr), 8);
+
+    // Copy Frame Counter
+    memcpy(&aes_iv[8], MAC_FRAME_AUX_FRAME_CNT_PTR_802_15_4(mac_frame_ptr), 4);
+
+    // Copy Nonce Security Level
+    aes_iv[12] = MAC_FRAME_AUX_SECURITY_CTRL_802_15_4(mac_frame_ptr) & 0x7;
+}
+
+/* Return the MIC length from the AUX - Security control bits 0-2
+ * the value of 4 is reserved and will return an error if set
+ * */
+uint8_t mac_frame_get_aux_mic_size(mac_frame_802_15_4_format_t *mac_frame_ptr)
+{
+    uint8_t value;
+
+    value = MAC_FRAME_AUX_SECURITY_CTRL_802_15_4(mac_frame_ptr) & 0x7;
+    if (value == 0)
+    {
+        return 0;
+    }
+    else if ((value == 1) || (value == 5))
+    {
+        return 4;
+    }
+    else if ((value == 2) || (value == 6))
+    {
+        return 8;
+    }
+    else if ((value == 3) || (value == 7))
+    {
+        return 16;
+    }
+    else
+    {
+        return MIC_ERROR; // error (value 4 is reserved and should not be set)
+    }
+}
+
+/* @fn      rx_aes_802_15_4
+ * @brief   Decrypts received frame, the frame type needs to match the structure defined in mac_802_15_4.h - mac_frame_802_15_4_format_t.
+ *          Note, the register key AES128 should be set before 1st call to this function.
+ * @param   mac_frame_ptr - frame pointer
+ * @param   frame_length  - length of data that was received in bytes
+ * @param   aes_job       - holds the parameters for decryption,
+ *          max_payload   - max allow size,
+ *          aes_key_ptr   - pointer for keys,
+ *          exp_src_addr  - expected src addr,
+ *          exp_dst_addr  - expected dest addr
+ *
+ * @return aes_results_e
+ * */
+aes_results_e rx_aes_802_15_4(mac_frame_802_15_4_format_t *mac_frame_ptr, uint16_t frame_length, dwt_aes_job_t *aes_job, uint16_t max_payload,
+    dwt_aes_key_t *aes_key_ptr, uint64_t exp_src_addr, uint64_t exp_dst_addr, dwt_aes_config_t *aes_config)
+{
+    uint8_t nonce[13];
+    int8_t status;
+    int16_t payload_len;
+    uint64_t src_addr, dst_addr;
+    security_state_e security_state;
+
+    /* the length of frame needs to be at least == header */
+    if ((frame_length - FCS_LEN) >= aes_job->header_len)
+    {
+        /* Get the MAC unencrypted data (MHR) */
+        dwt_readrxdata((uint8_t *)MHR_802_15_4_PTR(mac_frame_ptr), aes_job->header_len, 0);
+
+        /* Place a breakpoint here to see an unencrypted header */
+
+        get_src_and_dst_frame_addr(mac_frame_ptr, &src_addr, &dst_addr);
+        security_state = get_security_state(mac_frame_ptr);
+        // Check if we got a secure frame with the right destination and source addresses
+        if ((security_state != SECURITY_STATE_SECURE) || (exp_src_addr != src_addr) || (exp_dst_addr != dst_addr))
+        {
+            return AES_RES_ERROR_IGNORE_FRAME; // This is not for us
+        }
+
+        /* next get the MIC size */
+        aes_job->mic_size = mac_frame_get_aux_mic_size(mac_frame_ptr);
+        if (aes_job->mic_size == MIC_ERROR)
+        {
+            return AES_RES_ERROR_FRAME;
+        }
+
+        payload_len
+            = frame_length - (aes_job->header_len + aes_job->mic_size + FCS_LEN); /* to get unencrypted payload length subtract MIC, FCS and MHR lengths */
+        /* Check if payload_len is valid */
+        if ((payload_len < 0) || (payload_len > max_payload))
+        {
+            return AES_RES_ERROR_FRAME;
+        }
+
+        /* next get the nonce (SS-TWR AES example uses 13-byte nonce*/
+        mac_frame_get_nonce(mac_frame_ptr, nonce);
+
+        /* Fill AES job to decrypt the received packet */
+        aes_job->nonce = nonce;
+        aes_job->payload_len = payload_len;
+        aes_job->header = NULL; /* not used for decryption*/
+        aes_config->mic = dwt_mic_size_from_bytes(aes_job->mic_size);
+        // aes_config->aes_core_type=AES_core_type_CCM;
+        dwt_configure_aes(aes_config);
+
+        /* program the correct 128-bit key into DW3000 AES block*/
+        dwt_set_keyreg_128(&aes_key_ptr[MAC_FRAME_AUX_KEY_IDENTIFY_802_15_4(mac_frame_ptr) - 1]);
+
+        /* perform the decryption job, the unencrypted payload will be stored in aes_job->payload */
+        status = dwt_do_aes(aes_job, aes_config->aes_core_type);
+
+        /* "status" represents a last read of AES_STS_ID register.
+         * See DW3000 User Manual for details.
+         * */
+        if (status < 0)
+        { // Problem with Header/Payload length or mode selection
+            return AES_RES_ERROR_LENGTH;
+        }
+        else
+        {
+            if (status & DWT_AES_ERRORS)
+            { // One of the error status bits were raised
+                return AES_RES_ERROR;
+            }
+            else
+            {
+                return AES_RES_OK;
+            }
+        }
+    }
+    else
+    {
+        return AES_RES_ERROR_FRAME;
+    }
+}
+
+/* @fn      get_security_state
+ * @brief   This function checks if the security bit is set in the frame header corresponding security_state_e value.
+ *
+ * @param   frame pointer
+ * @return  security_state_e according to the state
+ */
+security_state_e get_security_state(mac_frame_802_15_4_format_t *mac_frame_ptr)
+{
+    if (MAC_FRAME_FRAME_CTRL_802_15_4(mac_frame_ptr, 0) & SECURITY_ENABLE_BIT_MASK)
+    {
+        return SECURITY_STATE_SECURE; // Protected
+    }
+    else
+    {
+        return SECURITY_STATE_NOT_SECURE; // Not protected
+    }
+}
+
+/* @fn      get_src_and_dst_frame_addr
+ * @brief   Copy the source and destination data from the frame header into given destination and source buffers.
+ *
+ * @param   mac_frame_ptr - pointer to MAC frame
+ * @param   src           - pointer to 64-bit integer where the src address will be stored
+ * @param   dst           - pointer to 64-bit integer where the dst address will be stored
+ * @return  None
+ */
+void get_src_and_dst_frame_addr(mac_frame_802_15_4_format_t *mac_frame_ptr, uint64_t *src, uint64_t *dst)
+{
+    uint8_t cnt1, *src_ptr, *dst_ptr;
+
+    *src = *dst = 0;
+    src_ptr = &MAC_FRAME_SRC_ADDR_802_15_4(mac_frame_ptr, 0);
+    dst_ptr = &MAC_FRAME_DEST_ADDR_ID_802_15_4(mac_frame_ptr, 0);
+
+    for (cnt1 = 0; cnt1 < sizeof(uint64_t); cnt1++)
+    {
+        *src |= (uint64_t)(src_ptr[cnt1]) << (8 * cnt1);
+        *dst |= (uint64_t)(dst_ptr[cnt1]) << (8 * cnt1);
+    }
+}

--- a/MAC_802_15_4/mac_802_15_4.h
+++ b/MAC_802_15_4/mac_802_15_4.h
@@ -1,0 +1,257 @@
+/*! ----------------------------------------------------------------------------
+ * @file    mac_802_15_4.h
+ * @brief   Functions that handle 802.15.4 frame
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+
+#ifndef _802_15_4_
+#define _802_15_4_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <deca_device_api.h>
+#include <shared_defines.h>
+
+#define NUM_OF_KEY_OPTIONS 3
+
+    /*  802_15_4 general MAC frame format
+     *
+     *  Octets:     1/2             0/1         0/2             0/2/8       0/2         0/2/8       Variable        Variable    Variable        2/4
+     *              Frame control   Seq number  Dest PAN ID     Dest Addr   Src PAN ID  Src Addr    Aux Sec Header  IEs         Frame Payload   FCS
+     */
+
+    /*Auxiliary security header bytes
+     *
+     * Octets:  1               0/4         0/1/5/9
+     *          Security ctrl   Frame count Key identifier
+     */
+
+    /*Auxiliary security header - Security ctrl byte
+     *
+     * Bits:    0-2                 3-4                     5                       6               7
+     *          Security level      Key identifier mode     Frame count suppression ASN in Nonce    Reserved
+     */
+
+    /* Auxiliary security header bytes */
+    typedef struct
+    {
+        uint8_t security_ctrl;    /* as defined above */
+        uint8_t frame_counter[4]; /* In the SS-TWR AES example, we are using a 4 byte counter */
+        uint8_t key_indentifier;  /* as defined above used to identify which key is used*/
+    } aux_security_t;
+
+#define EXTENDED_ADDR 8
+
+    /* MAC - MHR data fields. These field sizes are set for the sample frames of the SS-TWR AES demo
+     * the demo uses data type frames with 2 byte frame control, seq number, dest PAN ID, 64-bit source
+     * and destination addresses and the aux security header fields */
+    typedef struct
+    {
+        uint8_t frame_ctrl[2];
+        uint8_t sequence_num;
+        uint8_t dest_pan_id[2];
+        uint8_t dest_addr[EXTENDED_ADDR];
+        uint8_t src_addr[EXTENDED_ADDR];
+        aux_security_t aux_security; /* As defined above */
+        /*IE fields not in use*/
+    } mhr_802_15_4_t;
+
+    /* Aux security header byte 1, bits 0-2 */
+    typedef enum
+    {
+        AUX_SEC_LEVEL_DATA_CONF_OFF_MIC_0 = 0, /* Sec attribute None,    data conf off, data auth No,  MIC length 0  */
+        AUX_SEC_LEVEL_DATA_CONF_OFF_MIC_4,     /* Sec attribute mic 32,  data conf off, data auth Yes, MIC length 4  */
+        AUX_SEC_LEVEL_DATA_CONF_OFF_MIC_8,     /* Sec attribute mic 64,  data conf off, data auth Yes, MIC length 8  */
+        AUX_SEC_LEVEL_DATA_CONF_OFF_MIC_16,    /* Sec attribute mic 128, data conf off, data auth Yes, MIC length 16 */
+        AUX_SEC_LEVEL_RESERVED,                /* Reserved */
+        AUX_SEC_LEVEL_DATA_CONF_ON_MIC_4,      /* Sec attribute mic 32,  data conf on, data auth Yes, MIC length 4   */
+        AUX_SEC_LEVEL_DATA_CONF_ON_MIC_8,      /* Sec attribute mic 64,  data conf on, data auth Yes, MIC length 8   */
+        AUX_SEC_LEVEL_DATA_CONF_ON_MIC_16      /* Sec attribute mic 128, data conf on, data auth Yes, MIC length 16  */
+    } aux_security_level_e;
+
+    /* Aux security header byte 1, bits 3-4 */
+    typedef enum
+    {
+        AUX_KEY_IDEN_MODE_ORIGINATOR_RECIPIENT = 0,
+        AUX_KEY_IDEN_MODE_KEY_INDEX,
+        AUX_KEY_IDEN_MODE_4_OCTET_KEY_SOUCE_AND_INDEX,
+        AUX_KEY_IDEN_MODE_8_OCTET_KEY_SOUCE_AND_INDEX
+    } aux_key_indentifier_mode_e;
+
+    /* Aux security header byte 1, bit 5 */
+    typedef enum
+    {
+        AUX_FRAME_CNT_SUPPRESS_OFF = 0, /* Frame counter is carried */
+        AUX_FRAME_CNT_SUPPRESS_ON       /* Frame counter is not carried */
+    } aux_frame_cnt_suppress_e;
+
+    /* Aux security header byte 1, bit 6 */
+    typedef enum
+    {
+        AUX_ASN_IN_NOUNCE_FRAME_CNT_GEN_NONCE = 0,
+        AUX_ASN_IN_NOUNCE_FRAME_CNT_NOT_GEN_NONCE
+    } aux_asn_in_nonce_e;
+
+#define AUX_SECURITY_LEVEL_SHIFT_VALUE        0
+#define AUX_KEY_IDENTIFIER_MODE_SHIFT_VALUE   3
+#define AUX_FRAME_CNT_SUPPRESSION_SHIFT_VALUE 5
+#define AUX_ASN_IN_NONCE                      6
+
+#define AUX_FRAME_CNT_SIZE 4
+
+    /* This is the frame type - bits 0-2 that reside in the first byte of frame control */
+    typedef enum
+    {
+        MAC_FRAME_TYPE_802_15_4_BEACON = 0,
+        MAC_FRAME_TYPE_802_15_4_DATA,
+        MAC_FRAME_TYPE_802_15_4_ACK,
+        MAC_FRAME_TYPE_802_15_4_MAC_CMD,
+        MAC_FRAME_TYPE_802_15_4_RESERVED,
+        MAC_FRAME_TYPE_802_15_4_MULTI,
+        MAC_FRAME_TYPE_802_15_4_FRAGMENT,
+        MAC_FRAME_TYPE_802_15_4_EXTENDED
+    } mac_frame_type_802_15_4_e;
+
+    /* This is the frame security enabled - bit 3 that reside in the first byte of frame control */
+    typedef enum
+    {
+        MAC_SEC_EN_UN_PROTECTED = 0,
+        MAC_SEC_EN_PROTECTED
+    } mac_security_en_802_15_4_e;
+
+    /* This is the frame pending - bit 4 that reside in the first byte of frame control */
+    typedef enum
+    {
+        MAC_PEND_FRAME_NO_MORE_DATA = 0,
+        MAC_PEND_FRAME_MORE_DATA
+    } mac_pend_frame_802_15_4_e;
+
+    /* This is the frame AR - bit 5 that reside in the first byte of frame control */
+    typedef enum
+    {
+        MAC_AR_NO_ACK = 0,
+        MAC_AR_ACK
+    } mac_AR_802_15_4_e;
+
+    /* This is the frame PAN ID compress - bit 6 that reside in the first byte of frame control */
+    typedef enum
+    {
+        MAC_PEND_ID_COMPRESS_DEST_EXIST_SOURCE_NOT = 0,
+        MAC_PEND_ID_COMPRESS_NO
+    } mac_pand_id_compress_802_15_4_e;
+
+    /* This is the Seq num suppress - bit 0 that reside in the second byte of frame control */
+    typedef enum
+    {
+        MAC_SEQ_NUM_SUPP_PRESENT = 0,
+        MAC_SEQ_NUM_SUPP_NOT_PRESENT
+    } mac_seq_num_suppress_802_15_4_e;
+
+    /* This is the IE present - bit 1 that reside in the second byte of frame control */
+    typedef enum
+    {
+        MAC_IE_PRESENT_NO = 0,
+        MAC_IE_PRESENT_YES
+    } mac_ie_present_802_15_4_e;
+
+    /* This is the dest addr mode - bits 2,3 that reside in the second byte of frame control */
+    typedef enum
+    {
+        MAC_DEST_ADDR_MODE_NO_PEND_AND_ADDR = 0,
+        MAC_DEST_ADDR_MODE_RESERVED,
+        MAC_DEST_ADDR_MODE_SHORT_ADDR_16_BITS,
+        MAC_DEST_ADDR_MODE_EXT_ADDR_64_BITS
+    } mac_dest_addr_mode_802_15_4_e;
+
+/* This is the frame version - bits 4,5 that reside in the second byte of frame control */
+#define DATA_FRAME_VERSION 2 /* IEEE Std 802.15.4 */
+
+    /* This is the dest src mode - bits 6,7 that reside in the second byte of frame control */
+    typedef enum
+    {
+        MAC_SRC_ADDR_MODE_NO_PEND_AND_ADDR = 0,
+        MAC_SRC_ADDR_MODE_RESERVED,
+        MAC_SRC_ADDR_MODE_SHORT_ADDR_16_BITS,
+        MAC_SRC_ADDR_MODE_EXT_ADDR_64_BITS
+    } mac_src_addr_mode_802_15_4_e;
+
+/* Shift values to frame control byte 0 */
+#define MAC_FRAME_TYPE_SHIFT_VALUE             0
+#define MAC_FRAME_SECURITY_ENABLED_SHIFT_VALUE 3
+#define MAC_FRAME_FRAME_PENDING_SHIFT_VALUE    4
+#define MAC_FRAME_AR_SHIFT_VALUE               5
+#define MAC_FRAME_PAN_ID_SHIFT_VALUE           6
+
+/* Shift values to frame control byte 1 */
+#define MAC_FRAME_SEQ_NUM_SUPPRESS_SHIFT_VALUE 0
+#define MAC_FRAME_IE_PRESET_SHIFT_VALUE        1
+#define MAC_FRAME_DEST_ADDR_MODE_SHIFT_VALUE   2
+#define MAC_FRAME_FRAME_VER_SHIFT_VALUE        4
+#define MAC_FRAME_SRC_ADDR_MODE_SHIFT_VALUE    6
+
+#define SECURITY_ENABLE_BIT_MASK 0x8
+
+    /* This is the structure of the MAC frame. The structure defined here applies for the SS-TWR AES example frames
+     * the mhr_802_15_4_t defines a data frame with: with 2 byte frame control, seq number, dest PAN ID, 64-bit source
+     * and destination addresses and the aux security header fields
+     */
+    typedef struct
+    {
+        mhr_802_15_4_t mhr_802_15_4; /* MHR structure */
+        uint8_t *payload_ptr;        /* Pointer to the payload */
+        /*FCS will be added when transmitting this data*/
+    } mac_frame_802_15_4_format_t;
+
+    typedef enum
+    {
+        SECURITY_STATE_SECURE = 0,
+        SECURITY_STATE_NOT_SECURE
+    } security_state_e;
+
+#define MAC_FRAME_HEADER_SIZE(mac_frame_ptr) sizeof((mac_frame_ptr)->mhr_802_15_4)
+#define MHR_802_15_4_PTR(mac_frame_ptr)      &((mac_frame_ptr)->mhr_802_15_4)
+#define PAYLOAD_PTR_802_15_4(mac_frame_ptr)  (mac_frame_ptr)->payload_ptr
+
+#define MAC_FRAME_FRAME_CTRL_802_15_4(mac_frame_ptr, index)   (mac_frame_ptr)->mhr_802_15_4.frame_ctrl[index]
+#define MAC_FRAME_SEQ_NUM_802_15_4(mac_frame_ptr)             (mac_frame_ptr)->mhr_802_15_4.sequence_num
+#define MAC_FRAME_DEST_PAN_ID_802_15_4(mac_frame_ptr, index)  (mac_frame_ptr)->mhr_802_15_4.dest_pan_id[index]
+#define MAC_FRAME_DEST_ADDR_ID_802_15_4(mac_frame_ptr, index) (mac_frame_ptr)->mhr_802_15_4.dest_addr[index]
+//#define MAC_FRAME_SRC_PAN_ID_802_15_4(index)  MAC_frame_802_15_4_format.MHR_802_15_4.src_pan_id[index]
+#define MAC_FRAME_SRC_ADDR_802_15_4(mac_frame_ptr, index) (mac_frame_ptr)->mhr_802_15_4.src_addr[index]
+#define MAC_FRAME_SRC_ADDR_PTR_802_15_4(mac_frame_ptr)    (mac_frame_ptr)->mhr_802_15_4.src_addr
+
+#define MAC_FRAME_AUX_SECURITY_CTRL_802_15_4(mac_frame_ptr)     (mac_frame_ptr)->mhr_802_15_4.aux_security.security_ctrl
+#define MAC_FRAME_AUX_FRAME_CNT_802_15_4(mac_frame_ptr, index)  (mac_frame_ptr)->mhr_802_15_4.aux_security.frame_counter[index]
+#define MAC_FRAME_AUX_FRAME_CNT_PTR_802_15_4(mac_frame_ptr)     (mac_frame_ptr)->mhr_802_15_4.aux_security.frame_counter
+#define MAC_FRAME_AUX_FRAME_GET_CNT_802_15_4_PTR(mac_frame_ptr) (uint8_t *)(&(mac_frame_ptr)->mhr_802_15_4.aux_security.frame_counter)
+#define MAC_FRAME_AUX_KEY_IDENTIFY_802_15_4(mac_frame_ptr)      (mac_frame_ptr)->mhr_802_15_4.aux_security.key_indentifier
+
+    void mac_frame_init_mac_frame_ctrl(mac_frame_802_15_4_format_t *mac_frame_ptr);
+    void mac_frame_set_pan_ids_and_addresses_802_15_4(
+        mac_frame_802_15_4_format_t *mac_frame_ptr, uint16_t dest_pan_id, uint64_t dest_addr /*,uint16_t src_pan_id*/, uint64_t src_addr);
+    void mac_frame_update_sequence_number(mac_frame_802_15_4_format_t *mac_frame_ptr, uint8_t seq_num);
+    void mac_frame_update_aux_frame_cnt(mac_frame_802_15_4_format_t *mac_frame_ptr, uint32_t frame_cnt);
+    void mac_frame_set_aux_key_identifier(mac_frame_802_15_4_format_t *mac_frame_ptr, uint8_t key_index);
+    uint8_t mac_frame_get_aux_key_identifier(mac_frame_802_15_4_format_t *mac_frame_ptr);
+    uint32_t mac_frame_get_aux_frame_cnt(mac_frame_802_15_4_format_t *mac_frame_ptr);
+    void mac_frame_get_nonce(mac_frame_802_15_4_format_t *mac_frame_ptr, uint8_t *aes_iv);
+    void mac_frame_set_aux_security_control(mac_frame_802_15_4_format_t *mac_frame_ptr);
+    uint8_t mac_frame_get_aux_mic_size(mac_frame_802_15_4_format_t *mac_frame_ptr);
+    aes_results_e rx_aes_802_15_4(mac_frame_802_15_4_format_t *mac_frame_ptr, uint16_t frame_length, dwt_aes_job_t *aes_job, uint16_t max_payload,
+        dwt_aes_key_t *aes_key_ptr, uint64_t exp_src_addr, uint64_t exp_dst_addr, dwt_aes_config_t *aes_config);
+    security_state_e get_security_state(mac_frame_802_15_4_format_t *mac_frame_ptr);
+    void get_src_and_dst_frame_addr(mac_frame_802_15_4_format_t *mac_frame_ptr, uint64_t *src, uint64_t *dst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/config_options.c
+++ b/platform/config_options.c
@@ -1,0 +1,774 @@
+/*! ----------------------------------------------------------------------------
+ * @file    config_options.c
+ * @brief   Configuration options are defined here.
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+
+#include "config_options.h"
+
+/* String used to display measured distance on LCD screen (16 characters maximum). */
+char dist_str[16] = { 0 };
+
+/*
+ * TX Power Configuration Settings
+ */
+/* Values for the PG_DELAY and TX_POWER registers reflect the bandwidth and power of the spectrum at the current
+ * temperature. These values can be calibrated prior to taking reference measurements. */
+dwt_txconfig_t txconfig_options = {
+    0x34,       /* PG delay. */
+    0xfdfdfdfd, /* TX power. */
+    0x0         /*PG count*/
+};
+
+dwt_txconfig_t txconfig_options_ch9 = {
+    0x34,       /* PG delay. */
+    0xfefefefe, /* TX power. */
+    0x0         /*PG count*/
+};
+
+/*
+ * Configuration options for the following parameters:
+ * Channel: 5, 9
+ * PRF: 64
+ * Preamble Length: 64, 128, 512, 1024
+ * Preamble Code: 3/4 for 16MHz PRf, 9/10/11/12 for 64MHz PRF
+ * Data Rate: 0.85, 6.8
+ * STS: Length 64
+ */
+
+#ifdef CONFIG_OPTION_01
+/* Configuration option 01.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    9,                /* TX preamble code. Used in TX only. */
+    9,                /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,      /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_02
+/* Configuration option 02.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    9,                /* TX preamble code. Used in TX only. */
+    9,                /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,      /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_03
+/* Configuration option 03.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_04
+/* Configuration option 04.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_05
+/* Configuration option 05.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_06
+/* Configuration option 06.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_07
+/* Configuration option 07.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    9,                  /* TX preamble code. Used in TX only. */
+    9,                  /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,        /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_08
+/* Configuration option 08.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    9,                  /* TX preamble code. Used in TX only. */
+    9,                  /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,        /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_09
+/* Configuration option 09.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    10,               /* TX preamble code. Used in TX only. */
+    10,               /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,      /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_10
+/* Configuration option 10.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    10,               /* TX preamble code. Used in TX only. */
+    10,               /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,      /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_11
+/* Configuration option 11.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_12
+/* Configuration option 12.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_13
+/* Configuration option 13.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_14
+/* Configuration option 14.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,       /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_15
+/* Configuration option 15.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    10,                 /* TX preamble code. Used in TX only. */
+    10,                 /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,        /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_16
+/* Configuration option 16.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    10,                 /* TX preamble code. Used in TX only. */
+    10,                 /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_850K,        /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_17
+/* Configuration option 17.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    9,                /* TX preamble code. Used in TX only. */
+    9,                /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,       /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_18
+/* Configuration option 18.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    9,                /* TX preamble code. Used in TX only. */
+    9,                /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,       /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_19
+/* Configuration option 19.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_20
+/* Configuration option 20.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_21
+/* Configuration option 21.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_22
+/* Configuration option 22.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_23
+/* Configuration option 23.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    9,                  /* TX preamble code. Used in TX only. */
+    9,                  /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,         /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_24
+/* Configuration option 24.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    9,                  /* TX preamble code. Used in TX only. */
+    9,                  /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,         /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_25
+/* Configuration option 25.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    10,               /* TX preamble code. Used in TX only. */
+    10,               /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,       /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_26
+/* Configuration option 26.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                /* Channel number. */
+    DWT_PLEN_64,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,         /* Preamble acquisition chunk size. Used in RX only. */
+    10,               /* TX preamble code. Used in TX only. */
+    10,               /* RX preamble code. Used in RX only. */
+    3,                /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,       /* Data rate. */
+    DWT_PHRMODE_STD,  /* PHY header mode. */
+    DWT_PHRRATE_STD,  /* PHY header rate. */
+    (64 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,   /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,   /* STS length*/
+    DWT_PDOA_M0       /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_27
+/* Configuration option 27.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_28
+/* Configuration option 28.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_29
+/* Configuration option 29.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_30
+/* Configuration option 30.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                 /* Channel number. */
+    DWT_PLEN_512,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    10,                /* TX preamble code. Used in TX only. */
+    10,                /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (512 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,    /* STS length*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_31
+/* Configuration option 31.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    5,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    10,                 /* TX preamble code. Used in TX only. */
+    10,                 /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,         /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_32
+/* Configuration option 32.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+dwt_config_t config_options = {
+    9,                  /* Channel number. */
+    DWT_PLEN_1024,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,           /* Preamble acquisition chunk size. Used in RX only. */
+    10,                 /* TX preamble code. Used in TX only. */
+    10,                 /* RX preamble code. Used in RX only. */
+    3,                  /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,         /* Data rate. */
+    DWT_PHRMODE_STD,    /* PHY header mode. */
+    DWT_PHRRATE_STD,    /* PHY header rate. */
+    (1024 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,     /* Mode 1 STS enabled */
+    DWT_STS_LEN_64,     /* STS length*/
+    DWT_PDOA_M0         /* PDOA mode off */
+};
+#endif
+
+#ifdef CONFIG_OPTION_33
+/* Configuration option 33.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 128
+ */
+dwt_config_t config_options = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_1,    /* Mode 1 STS enabled */
+    DWT_STS_LEN_128,   /* (STS length  in blocks of 8) - 1*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+
+/* Configuration option SP3.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 128, STS Mode 3
+ */
+dwt_config_t config_option_sp3 = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_ND,   /* Mode 3 STS (no data) enabled */
+    DWT_STS_LEN_128,   /* (STS length  in blocks of 8) - 1*/
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+
+/* Configuration option SP0.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, No STS
+ */
+dwt_config_t config_option_sp0 = {
+    5,                 /* Channel number. */
+    DWT_PLEN_128,      /* Preamble length. Used in TX only. */
+    DWT_PAC8,          /* Preamble acquisition chunk size. Used in RX only. */
+    9,                 /* TX preamble code. Used in TX only. */
+    9,                 /* RX preamble code. Used in RX only. */
+    3,                 /* 0 to use standard 8 symbol SFD, 1 to use non-standard 8 symbol, 2 for non-standard 16 symbol SFD and 3 for 4z 8 symbol SDF type */
+    DWT_BR_6M8,        /* Data rate. */
+    DWT_PHRMODE_STD,   /* PHY header mode. */
+    DWT_PHRRATE_STD,   /* PHY header rate. */
+    (128 + 1 + 8 - 8), /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
+    DWT_STS_MODE_OFF,  /* STS Off */
+    DWT_STS_LEN_128,   /* Ignore value when STS is disabled */
+    DWT_PDOA_M0        /* PDOA mode off */
+};
+
+#endif

--- a/platform/config_options.h
+++ b/platform/config_options.h
@@ -1,0 +1,243 @@
+/*! ----------------------------------------------------------------------------
+ * @file    config_options.h
+ * @brief   Configuration options are selected here.
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+
+#include <deca_device_api.h>
+
+#ifndef EXAMPLES_CONFIG_OPTIONS_H_
+#define EXAMPLES_CONFIG_OPTIONS_H_
+
+/* Index values for errors in array */
+#define CRC_ERR_IDX                0
+#define RSE_ERR_IDX                1
+#define PHE_ERR_IDX                2
+#define SFDTO_ERR_IDX              3
+#define PTO_ERR_IDX                4
+#define RTO_ERR_IDX                5
+#define SPICRC_ERR_IDX             6
+#define TXTO_ERR_IDX               7
+#define ARFE_ERR_IDX               8
+#define TS_MISMATCH_ERR_IDX        9
+#define BAD_FRAME_ERR_IDX          10
+#define PREAMBLE_COUNT_ERR_IDX     11
+#define CP_QUAL_ERR_IDX            12
+#define STS_PREAMBLE_ERR           13
+#define STS_PEAK_GROWTH_RATE_ERR   14
+#define STS_ADC_COUNT_ERR          15
+#define STS_SFD_COUNT_ERR          16
+#define STS_LATE_FIRST_PATH_ERR    17
+#define STS_LATE_COARSE_EST_ERR    18
+#define STS_COARSE_EST_EMPTY_ERR   19
+#define STS_HIGH_NOISE_THREASH_ERR 20
+#define STS_NON_TRIANGLE_ERR       21
+#define STS_LOG_REG_FAILED_ERR     22
+
+/*
+ * Number of ranges to attempt in test
+ */
+#define RANGE_COUNT 200
+
+/* Compensation value for CPU
+ * The time taken to receive the poll frame, check for errors,
+ * calculate length, read content, get poll timestamp,
+ * calculate response timestamp and send delayed response with timestamp will
+ * be different for each device.
+ * Adjusting this value lower and lower until dwt_starttx() starts returning
+ * DWT_ERROR status allows the user to tweak their system to calculate the
+ * shortest turn-around time for messages.
+ */
+#define CPU_PROCESSING_TIME 400
+
+/*
+ * SPI Rate Configuration Settings
+ */
+#define CONFIG_SPI_FAST_RATE
+//#define CONFIG_SPI_SLOW_RATE
+
+/*
+ * Changing threshold to 5ns for DW3000 B0 red board devices.
+ * ~10% of ranging attempts have a larger than usual difference between Ipatov and STS.
+ * A larger threshold allows for better coverage with this coverage.
+ * This should be fixed for DW3000 C0 devices.
+ */
+#define TS_MISMATCH_THRESHOLD 5 * 64 /* 64 = 1 ns --> 5 ns */
+
+/*
+ * Please note that a PRF of 16 MHz and a STS PRF of 64 MHz will not be supported for the DW3000.
+ */
+
+/* Configuration option 01.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_01
+
+/* Configuration option 02.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_02
+
+/* Configuration option 03.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_03
+
+/* Configuration option 04.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_04
+
+/* Configuration option 05.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_05
+
+/* Configuration option 06.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_06
+
+/* Configuration option 07.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_07
+
+/* Configuration option 08.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_08
+
+/* Configuration option 09.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_09
+
+/* Configuration option 10.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_10
+
+/* Configuration option 11.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_11
+
+/* Configuration option 12.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_12
+
+/* Configuration option 13.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_13
+
+/* Configuration option 14.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_14
+
+/* Configuration option 15.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_15
+
+/* Configuration option 16.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_16
+
+/* Configuration option 17.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_17
+
+/* Configuration option 18.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_18
+
+/* Configuration option 19.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_19
+
+/* Configuration option 20.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_20
+
+/* Configuration option 21.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 850k, STS Length 64
+ */
+//#define CONFIG_OPTION_21
+
+/* Configuration option 22.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_22
+
+/* Configuration option 23.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_23
+
+/* Configuration option 24.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_24
+
+/* Configuration option 25.
+ * Channel 5, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_25
+
+/* Configuration option 26.
+ * Channel 9, PRF 64M, Preamble Length 64, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_26
+
+/* Configuration option 27.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_27
+
+/* Configuration option 28.
+ * Channel 9, PRF 64M, Preamble Length 128, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_28
+
+/* Configuration option 29.
+ * Channel 5, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_29
+
+/* Configuration option 30.
+ * Channel 9, PRF 64M, Preamble Length 512, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_30
+
+/* Configuration option 31.
+ * Channel 5, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_31
+
+/* Configuration option 32.
+ * Channel 9, PRF 64M, Preamble Length 1024, PAC 8, Preamble code 10, Data Rate 6.8M, STS Length 64
+ */
+//#define CONFIG_OPTION_32
+
+/* Configuration option 33.
+ * Channel 5, PRF 64M, Preamble Length 128, PAC 8, Preamble code 9, Data Rate 6.8M, STS Length 128
+ */
+#define CONFIG_OPTION_33
+
+extern char dist_str[16];
+
+#endif /* EXAMPLES_CONFIG_OPTIONS_H_ */

--- a/platform/dw3000_hw.c
+++ b/platform/dw3000_hw.c
@@ -11,6 +11,12 @@ LOG_MODULE_REGISTER(dw3000, CONFIG_DW3000_LOG_LEVEL);
 
 #define DW_INST DT_INST(0, decawave_dw3000)
 
+K_THREAD_STACK_DEFINE(dw3000_stack_area, 1024);
+static struct k_work_q dw3000_work_q;
+static const struct k_work_queue_config dw3000_wq_config = {
+    .name = "dw3000_wq"
+};
+
 static struct gpio_callback gpio_cb;
 static struct k_work dw3000_isr_work;
 
@@ -73,13 +79,29 @@ static void dw3000_hw_isr_work_handler(struct k_work* item)
 static void dw3000_hw_isr(const struct device* dev, struct gpio_callback* cb,
 						  uint32_t pins)
 {
-	k_work_submit(&dw3000_isr_work);
+	k_work_submit_to_queue(&dw3000_work_q, &dw3000_isr_work);
+}
+
+void dw3000_init_workqueue(void) {
+    static bool initialized = false;
+    if (initialized) {
+        return;
+    }
+    initialized = true;
+
+	k_work_queue_start(&dw3000_work_q,
+					dw3000_stack_area,
+					K_THREAD_STACK_SIZEOF(dw3000_stack_area),
+					K_PRIO_PREEMPT(0),
+					&dw3000_wq_config);
+
+    k_work_init(&dw3000_isr_work, dw3000_hw_isr_work_handler);
 }
 
 int dw3000_hw_init_interrupt(void)
 {
 	if (conf.gpio_irq.port) {
-		k_work_init(&dw3000_isr_work, dw3000_hw_isr_work_handler);
+		dw3000_init_workqueue();
 
 		gpio_pin_configure_dt(&conf.gpio_irq, GPIO_INPUT);
 		gpio_init_callback(&gpio_cb, dw3000_hw_isr, BIT(conf.gpio_irq.pin));

--- a/platform/dw3000_spi.c
+++ b/platform/dw3000_spi.c
@@ -122,7 +122,14 @@ int32_t dw3000_spi_write_crc(uint16_t headerLength, const uint8_t* headerBuffer,
 		.count = ARRAY_SIZE(tx_buf),
 	};
 
-	return spi_transceive(spi, spi_cfg, &tx, NULL);
+	struct k_poll_signal sig;
+	k_poll_signal_init(&sig);
+	int ret = spi_transceive_signal(spi, spi_cfg, &tx, NULL, &sig);
+
+	struct k_poll_event evt = K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &sig);
+	k_poll(&evt, 1, K_FOREVER);
+
+	return ret;
 }
 
 int32_t dw3000_spi_write(uint16_t headerLength, const uint8_t* headerBuffer,
@@ -143,7 +150,14 @@ int32_t dw3000_spi_write(uint16_t headerLength, const uint8_t* headerBuffer,
 		.count = ARRAY_SIZE(tx_buf),
 	};
 
-	return spi_transceive(spi, spi_cfg, &tx, NULL);
+	struct k_poll_signal sig;
+	k_poll_signal_init(&sig);
+	int ret = spi_transceive_signal(spi, spi_cfg, &tx, NULL, &sig);
+
+	struct k_poll_event evt = K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &sig);
+	k_poll(&evt, 1, K_FOREVER);
+
+	return ret;
 }
 
 int32_t dw3000_spi_read(uint16_t headerLength, uint8_t* headerBuffer,
@@ -172,7 +186,12 @@ int32_t dw3000_spi_read(uint16_t headerLength, uint8_t* headerBuffer,
 		.count = ARRAY_SIZE(rx_buf),
 	};
 
-	int ret = spi_transceive(spi, spi_cfg, &tx, &rx);
+	struct k_poll_signal sig;
+	k_poll_signal_init(&sig);
+	int ret = spi_transceive_signal(spi, spi_cfg, &tx, &rx, &sig);
+
+	struct k_poll_event evt = K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SIGNAL, K_POLL_MODE_NOTIFY_ONLY, &sig);
+	k_poll(&evt, 1, K_FOREVER);
 
 #if (CONFIG_SOC_NRF52840_QIAA)
 	/*

--- a/platform/shared_defines.h
+++ b/platform/shared_defines.h
@@ -1,0 +1,65 @@
+/*! ----------------------------------------------------------------------------
+ * @file    shared_defines.h
+ * @brief   Global definitions are found here
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+
+#ifndef _SHARE_DEF_
+#define _SHARE_DEF_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifdef STM32F429xx
+#include <main.h>
+#endif // STM32F429xx
+
+#define SPEED_OF_LIGHT   (299702547)
+#define FRAME_LEN_MAX    (127)
+#define FRAME_LEN_MAX_EX (1023)
+
+#define RXFLEN_MASK    0x0000007FUL /* Receive Frame Length (0 to 127) */
+#define RXFL_MASK_1023 0x000003FFUL /* Receive Frame Length Extension (0 to 1023) */
+
+#define RESP_MSG_TS_LEN  4
+#define FINAL_MSG_TS_LEN 4
+
+/* UWB microsecond (uus) to device time unit (dtu, around 15.65 ps) conversion factor.
+ * 1 uus = 512 / 499.2 s and 1 s = 499.2 * 128 dtu. */
+#define UUS_TO_DWT_TIME 63898
+
+#define TX_CHANGEABLE_DATA  (10) /*Can change the length of TX data by this size*/
+#define MINIMAL_DATA_LENGTH (11) /*The TX length will be at least the buffer below*/
+#define SIMPLE_TX_DATA_SIZE (MINIMAL_DATA_LENGTH + TX_CHANGEABLE_DATA)
+#define TX_LENGTH_BYTE_POS  (2) /*This byte index represent the total length of the TX data*/
+
+    typedef enum
+    {
+        DBL_BUFF_ERR_TYPE_UNKNOWN = -1, /*Unknown yet*/
+        DBL_BUFF_ERR_TYPE_OK,           /*No error*/
+        DBL_BUFF_ERR_TYPE_TIMEOUT,      /*Timeout*/
+        DBL_BUFF_ERR_TYPE_ERROR,        /*Error*/
+        DBL_BUFF_ERR_TYPE_GOT_UNNEEDED_DATA,
+    } dbl_buff_error_type_e;
+
+    typedef enum
+    {
+        AES_RES_OK = 0,
+        AES_RES_ERROR_LENGTH = -1,
+        AES_RES_ERROR = -2,
+        AES_RES_ERROR_FRAME = -3,
+        AES_RES_ERROR_IGNORE_FRAME = -4
+    } aes_results_e;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/shared_functions.c
+++ b/platform/shared_functions.c
@@ -1,0 +1,623 @@
+/*! ----------------------------------------------------------------------------
+ * @file    shared_functions.c
+ * @brief   Global functions are found here
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+
+#include <config_options.h>
+#include <deca_device_api.h>
+#include <deca_types.h>
+#include <shared_defines.h>
+#include <shared_functions.h>
+#include <stdlib.h>
+
+extern dwt_config_t config_options;
+
+/*Reference look-up table to calculate TxPower boost depending on frame duration
+ * Using two different tables as per logarithmic calculation:
+ *   - 1000us to 200us range - index unit of 25us
+ *   - 200us to 70us -- index unit of 10us
+ * The table values are in steps 0f 0.1dB
+ * This allow to have a maximum granularity of 0.5dB between two frame durations, which is
+ * in the magnitude of the DW3XXX TxOutput setting.
+ */
+
+const uint8_t txpower_boost_per_frame_duration_1000_200_us[LUT_1000_200_US_NUM] = {
+    0,  // 1000us
+    1,  // 975us  -> 1*0.1dB boost between 975us and 1000us frames
+    2,  // 950us  -> 2*0.1dB boost between 950us and 1000us frames
+    3,  // 925us
+    4,  // 900us
+    5,  // 875us
+    6,  // 850us
+    7,  // 825us
+    8,  // 800us
+    9,  // 775us
+    10, // 750us
+    11, // 725us
+    13, // 700us
+    15, // 675us
+    17, // 650us
+    19, // 625us
+    21, // 600us
+    23, // 575us
+    25, // 550us
+    27, // 525us
+    29, // 500us
+    31, // 475us
+    33, // 450us
+    35, // 425us
+    38, // 400us
+    41, // 375us
+    44, // 350us
+    47, // 325us
+    50, // 300us
+    54, // 275us
+    58, // 250us
+    63, // 225us
+    68  // 200us
+};
+
+const uint8_t txpower_boost_per_frame_duration_200_70_us[LUT_200_70_US_NUM] = {
+    68,  // 200us  -> 68*0.1dB boost between 200us frame and 1000us frame.
+    70,  // 190us  -> 70*0.1dB boost between 190us and 1000us frame
+    72,  // 180us
+    74,  // 170us
+    77,  // 160us
+    80,  // 150us
+    83,  // 140us
+    86,  // 130us
+    89,  // 120us
+    93,  // 110us
+    97,  // 100us
+    102, // 90us
+    107, // 80us
+    113  // 70us
+};
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn calculate_power_boost()
+ *
+ * @brief Calculation the allowed power boost for a frame_duration_us frame relatively to a 1ms frame.
+ *
+ * @param reg: uint16_t duration of frame..
+ *
+ * @return boost: the amount of boost in 0.1dB steps which is allowed when transmitting the frame_dur_us frame
+ *                relatively to a 1ms frame. For example, if the frame duration is 500us, then relatively to 1ms,
+ *                a 3dB boost is allowed, and the function will return 30.
+ */
+uint8_t calculate_power_boost(uint16_t frame_duration_us)
+{
+
+    const uint8_t *lut = NULL;
+    uint16_t lut_i;
+    uint16_t lut_num;
+    uint16_t lut_min;
+    uint16_t lut_step;
+    uint16_t limit;
+
+    // If the frame is longer than the reference duration, then no boost to apply
+    if (frame_duration_us >= FRAME_DURATION_REF)
+    {
+        return LUT_1000_200_US_MIN_BST;
+    }
+    else if (frame_duration_us < LUT_200_70_US_MIN) // If frame shorter than 70us apply the maximum boost
+    {
+        return LUT_200_70_US_MAX_BST;
+    }
+    else if (frame_duration_us > LUT_1000_200_US_MIN) // Select LUT table for frame 1000us > duration > 200us
+    {
+        lut_num = LUT_1000_200_US_NUM;
+        lut_min = LUT_1000_200_US_MIN;
+        lut_step = LUT_1000_200_US_STEP;
+        lut = txpower_boost_per_frame_duration_1000_200_us;
+    }
+    else // Select LUT table for frame 200us > duration > 70us
+    {
+        lut_num = LUT_200_70_US_NUM;
+        lut_min = LUT_200_70_US_MIN;
+        lut_step = LUT_200_70_US_STEP;
+        lut = txpower_boost_per_frame_duration_200_70_us;
+    }
+
+    // Calculating the LUT index corresponding to the frame duration
+    lut_i = (lut_num - (frame_duration_us - lut_min) / lut_step);
+    limit = (lut_num - lut_i) * lut_step + lut_min;
+
+    // Selecting the index that gives the closest LUT duration to the one passed as argument.
+    if (abs(frame_duration_us - limit) > lut_step / 2)
+    {
+        lut_i--;
+    }
+
+    // Boost is stored in the LUT at the calculated index - 1.
+    // -1 to account for index 0
+    // lut_i cannot be == 0 or > lut_num here
+    return lut[lut_i - 1];
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn check_for_status_errors()
+ *
+ * @brief This function is used to get a value to increase the delay timer by dependent on the current TX preamble length set.
+ *
+ * @param reg: uint32_t value representing the current status register value.
+ * @param errors: pointer to a uint32_t buffer that contains the sum of different errors logged during program operation.
+ *
+ * @return none
+ */
+void check_for_status_errors(uint32_t reg, uint32_t *errors)
+{
+    uint16_t stsStatus = 0;
+
+    if (!(reg & DWT_INT_RXFCG_BIT_MASK))
+    {
+        errors[BAD_FRAME_ERR_IDX] += 1;
+    }
+
+    if (reg & DWT_INT_RXFSL_BIT_MASK)
+    {
+        errors[RSE_ERR_IDX] += 1;
+    }
+
+    if (reg & DWT_INT_RXPHE_BIT_MASK)
+    {
+        errors[PHE_ERR_IDX] += 1;
+    }
+
+    if (reg & DWT_INT_RXPTO_BIT_MASK)
+    {
+        errors[PTO_ERR_IDX] += 1;
+    }
+
+    if (reg & DWT_INT_ARFE_BIT_MASK)
+    {
+        errors[ARFE_ERR_IDX] += 1;
+    }
+
+    if ((reg & DWT_INT_RXFR_BIT_MASK) && !(reg & DWT_INT_RXFCG_BIT_MASK))
+    {
+        errors[CRC_ERR_IDX] += 1;
+    }
+
+    if ((reg & DWT_INT_RXFTO_BIT_MASK) || (reg & SYS_STATUS_ALL_RX_TO))
+    {
+        errors[RTO_ERR_IDX] += 1;
+    }
+
+    if (reg & DWT_INT_RXSTO_BIT_MASK)
+    {
+        errors[SFDTO_ERR_IDX] += 1;
+    }
+
+    if (reg & DWT_INT_CPERR_BIT_MASK)
+    {
+        // There is a general STS error
+        errors[STS_PREAMBLE_ERR] += 1;
+
+        // Get the status for a more detailed error reading of what went wrong with the STS
+        dwt_readstsstatus(&stsStatus, 0);
+        if (stsStatus & 0x100)
+        {
+            // Peak growth rate warning
+            errors[STS_PEAK_GROWTH_RATE_ERR] += 1;
+        }
+        if (stsStatus & 0x080)
+        {
+            // ADC count warning
+            errors[STS_ADC_COUNT_ERR] += 1;
+        }
+        if (stsStatus & 0x040)
+        {
+            // SFD count warning
+            errors[STS_SFD_COUNT_ERR] += 1;
+        }
+        if (stsStatus & 0x020)
+        {
+            // Late first path estimation
+            errors[STS_LATE_FIRST_PATH_ERR] += 1;
+        }
+        if (stsStatus & 0x010)
+        {
+            // Late coarse estimation
+            errors[STS_LATE_COARSE_EST_ERR] += 1;
+        }
+        if (stsStatus & 0x008)
+        {
+            // Coarse estimation empty
+            errors[STS_COARSE_EST_EMPTY_ERR] += 1;
+        }
+        if (stsStatus & 0x004)
+        {
+            // High noise threshold
+            errors[STS_HIGH_NOISE_THREASH_ERR] += 1;
+        }
+        if (stsStatus & 0x002)
+        {
+            // Non-triangle
+            errors[STS_NON_TRIANGLE_ERR] += 1;
+        }
+        if (stsStatus & 0x001)
+        {
+            // Logistic regression failed
+            errors[STS_LOG_REG_FAILED_ERR] += 1;
+        }
+    }
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn get_rx_delay_time_txpreamble()
+ *
+ * @brief This function is used to get a value to increase the delay timer by dependent on the current TX preamble length set.
+ *
+ * @param None
+ *
+ * @return delay_time - a uint32_t value indicating the required increase needed to delay the time by.
+ */
+uint32_t get_rx_delay_time_txpreamble(void)
+{
+    uint32_t delay_time = 0;
+    /* Standard delay values for preamble lengths of 32, 64, 72 & 128 should be adequate.
+     * Additional time delay will be needed for larger preamble lengths.
+     * Delay required is dependent on the preamble length as it increases the frame length. */
+    switch (config_options.txPreambLength)
+    {
+    case DWT_PLEN_256:
+        delay_time += 128; /* 256 - 128 */
+        break;
+    case DWT_PLEN_512:
+        delay_time += 384; /* 512 - 128 */
+        break;
+    case DWT_PLEN_1024:
+        delay_time += 896; /* 1024 - 128 */
+        break;
+    case DWT_PLEN_1536:
+        delay_time += 1408; /* 1536 - 128 */
+        break;
+    case DWT_PLEN_2048:
+        delay_time += 1920; /* 2048 - 128 */
+        break;
+    case DWT_PLEN_4096:
+        delay_time += 3968; /* 4096 - 128 */
+        break;
+    case DWT_PLEN_32:
+    case DWT_PLEN_64:
+    case DWT_PLEN_72:
+    case DWT_PLEN_128:
+    default:
+        break;
+    }
+
+    return delay_time;
+}
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn get_rx_delay_time_data_rate()
+ *
+ * @brief This function is used to get a value to increase the delay timer by dependent on the current data rate set.
+ *
+ * @param None
+ *
+ * @return delay_time - a uint32_t value indicating the required increase needed to delay the time by.
+ */
+uint32_t get_rx_delay_time_data_rate(void)
+{
+    uint32_t delay_time = 0;
+    /*
+     * If data rate is set to 850k (slower rate),
+     * increase the delay time
+     */
+    switch (config_options.dataRate)
+    {
+    case DWT_BR_850K:
+        delay_time += 200;
+        break;
+    case DWT_BR_6M8:
+    default:
+        break;
+    }
+
+    return delay_time;
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn set_delayed_rx_time()
+ *
+ * @brief This function is used to set the delayed RX time before running dwt_rxenable()
+ *
+ * @param delay - This is a defined delay value (usually POLL_TX_TO_RESP_RX_DLY_UUS)
+ * @param config_options - pointer to dwt_config_t configuration structure that is in use at the time this function
+ *                         is called.
+ *
+ * @return None
+ */
+void set_delayed_rx_time(uint32_t delay, dwt_config_t *config_options)
+{
+    uint32_t delay_time = delay;
+
+    switch (config_options->txPreambLength)
+    {
+    case DWT_PLEN_32:
+        delay_time -= 32;
+        break;
+    case DWT_PLEN_64:
+        delay_time -= 64;
+        break;
+    case DWT_PLEN_72:
+        delay_time -= 72;
+        break;
+    case DWT_PLEN_128:
+        delay_time -= 128;
+        break;
+    case DWT_PLEN_256:
+        delay_time -= 256;
+        break;
+    case DWT_PLEN_512:
+        delay_time -= 512;
+        break;
+    case DWT_PLEN_1024:
+        delay_time -= 1024;
+        break;
+    case DWT_PLEN_1536:
+        delay_time -= 1536;
+        break;
+    case DWT_PLEN_2048:
+    case DWT_PLEN_4096:
+        delay_time -= 2048;
+        break;
+    default:
+        break;
+    }
+
+    /* Length of the STS effects the size of the frame also.
+     * This means the delay required is greater for larger STS lengths. */
+    delay_time += ((1 << (config_options->stsLength + 2)) * 8);
+
+    dwt_setdelayedtrxtime((uint32_t)((delay_time * UUS_TO_DWT_TIME) >> 8));
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn set_resp_rx_timeout()
+ *
+ * @brief This function is used to set the RX timeout value
+ *
+ * @param delay - This is a defined delay value (usually RESP_RX_TIMEOUT_UUS)
+ * @param config_options - pointer to dwt_config_t configuration structure that is in use at the time this function
+ *                         is called.
+ *
+ * @return None
+ */
+void set_resp_rx_timeout(uint32_t delay, dwt_config_t *config_options)
+{
+    /*
+     * The program will need to adjust the timeout value depending on the size of the frame
+     * Different sized frames require different time delays.
+     */
+    uint32_t delay_time = delay + get_rx_delay_time_data_rate() + get_rx_delay_time_txpreamble() + 500;
+
+    /* Length of the STS effects the size of the frame also.
+     * This means the delay required is greater for larger STS lengths. */
+    switch (config_options->stsLength)
+    {
+    case DWT_STS_LEN_256:
+    case DWT_STS_LEN_512:
+    case DWT_STS_LEN_1024:
+    case DWT_STS_LEN_2048:
+        delay_time += ((1 << (config_options->stsLength + 2)) * 8);
+        break;
+    case DWT_STS_LEN_32:
+    case DWT_STS_LEN_64:
+    case DWT_STS_LEN_128:
+    default:
+        break;
+    }
+
+    dwt_setrxtimeout(delay_time);
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn resp_msg_get_ts()
+ *
+ * @brief Read a given timestamp value from the response message. In the timestamp fields of the response message, the
+ *        least significant byte is at the lower address.
+ *
+ * @param  ts_field  pointer on the first byte of the timestamp field to get
+ *         ts  timestamp value
+ *
+ * @return none
+ */
+void resp_msg_get_ts(uint8_t *ts_field, uint32_t *ts)
+{
+    int i;
+    *ts = 0;
+    for (i = 0; i < RESP_MSG_TS_LEN; i++)
+    {
+        *ts += (uint32_t)ts_field[i] << (i * 8);
+    }
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn get_tx_timestamp_u64()
+ *
+ * @brief Get the TX time-stamp in a 64-bit variable.
+ *        /!\ This function assumes that length of time-stamps is 40 bits, for both TX and RX!
+ *
+ * @param  none
+ *
+ * @return  64-bit value of the read time-stamp.
+ */
+uint64_t get_tx_timestamp_u64(void)
+{
+    uint8_t ts_tab[5];
+    uint64_t ts = 0;
+    int8_t i;
+    dwt_readtxtimestamp(ts_tab);
+    for (i = 4; i >= 0; i--)
+    {
+        ts <<= 8;
+        ts |= ts_tab[i];
+    }
+    return ts;
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn get_rx_timestamp_u64()
+ *
+ * @brief Get the RX time-stamp in a 64-bit variable.
+ *        /!\ This function assumes that length of time-stamps is 40 bits, for both TX and RX!
+ *
+ * @param  none
+ *
+ * @return  64-bit value of the read time-stamp.
+ */
+uint64_t get_rx_timestamp_u64(void)
+{
+    uint8_t ts_tab[5];
+    uint64_t ts = 0;
+    int8_t i;
+    dwt_readrxtimestamp(ts_tab, 0);
+    for (i = 4; i >= 0; i--)
+    {
+        ts <<= 8;
+        ts |= ts_tab[i];
+    }
+    return ts;
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn final_msg_get_ts()
+ *
+ * @brief Read a given timestamp value from the final message. In the timestamp fields of the final message, the least
+ *        significant byte is at the lower address.
+ *
+ * @param  ts_field  pointer on the first byte of the timestamp field to read
+ *         ts  timestamp value
+ *
+ * @return none
+ */
+void final_msg_get_ts(const uint8_t *ts_field, uint32_t *ts)
+{
+    uint8_t i;
+    *ts = 0;
+    for (i = 0; i < FINAL_MSG_TS_LEN; i++)
+    {
+        *ts += ((uint32_t)ts_field[i] << (i * 8));
+    }
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn final_msg_set_ts()
+ *
+ * @brief Fill a given timestamp field in the final message with the given value. In the timestamp fields of the final
+ *        message, the least significant byte is at the lower address.
+ *
+ * @param  ts_field  pointer on the first byte of the timestamp field to fill
+ *         ts  timestamp value
+ *
+ * @return none
+ */
+void final_msg_set_ts(uint8_t *ts_field, uint64_t ts)
+{
+    uint8_t i;
+    for (i = 0; i < FINAL_MSG_TS_LEN; i++)
+    {
+        ts_field[i] = (uint8_t)ts;
+        ts >>= 8;
+    }
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @fn resp_msg_set_ts()
+ *
+ * @brief Fill a given timestamp field in the response message with the given value. In the timestamp fields of the
+ *        response message, the least significant byte is at the lower address.
+ *
+ * @param  ts_field  pointer on the first byte of the timestamp field to fill
+ *         ts  timestamp value
+ *
+ * @return none
+ */
+void resp_msg_set_ts(uint8_t *ts_field, const uint64_t ts)
+{
+    uint8_t i;
+    for (i = 0; i < RESP_MSG_TS_LEN; i++)
+    {
+        ts_field[i] = (uint8_t)(ts >> (i * 8));
+    }
+}
+
+/*! ------------------------------------------------------------------------------------------------------------------
+ * @brief This function will continuously read the system status register until it matches the bits set in the mask
+ *        input parameter. It will then exit the function.
+ *        This is useful to use when waiting on particular events to occurs. For example, the user could wait for a
+ *        good UWB frame to be received and/or no receive errors have occurred.
+ *        The lower 32-bits of the system status register will be read in a while loop. Each iteration of the loop will check if a matching
+ *        mask value for the higher 32-bits of the system status register is set. If the mask value is set in the higher 32-bits of the system
+ *        status register, the function will return that value along with the last recorded value of the lower 32-bits of the system status
+ *        register. Thus, the user should be aware that this function will not wait for high and low mask values to be set in both the low and high
+ *        system status registers. Alternatively, the user can call this function to *only* check the higher or lower system status registers.
+ *
+ * input parameters
+ * @param lo_result - A pointer to a uint32_t that will contain the final value of the system status register (lower 32 bits).
+ *                    Pass in a NULL pointer to ignore returning this value.
+ * @param hi_result - A pointer to a uint32_t that will contain the final value of the system status register (higher 32 bits).
+ *                    Pass in a NULL pointer to ignore returning this value.
+ * @param lo_mask - a uint32 mask value that is used to check for certain bits to be set in the system status register (lower 32 bits).
+ *               Example values to use are as follows:
+ *               DWT_INT_TXFRS_BIT_MASK - Wait for a TX frame to be sent.
+ *               SYS_STATUS_RXFCG_BIT_MASK | SYS_STATUS_ALL_RX_ERR - Wait for frame to be received and no reception errors.
+ *               SYS_STATUS_RXFCG_BIT_MASK | SYS_STATUS_ALL_RX_TO | SYS_STATUS_ALL_RX_ERR - Wait for frame to be received and no receive timeout errors
+ *                                                                                          and no reception errors.
+ *               SYS_STATUS_RXFR_BIT_MASK | SYS_STATUS_ALL_RX_TO | SYS_STATUS_ALL_ND_RX_ERR - Wait for packet to be received and no receive timeout errors
+ *                                                                                            and no reception errors.
+ *                                                                                            These flags are useful when polling for STS Mode 3 (no data)
+ *                                                                                            packets.
+ *               0 - The function will not wait for any bits in the system status register (lower 32 bits).
+ * @param hi_mask - a uint32 mask value that is used to check for certain bits to be set in the system status register (higher 32 bits).
+ *               Example values to use are as follows:
+ *               SYS_STATUS_HI_CCA_FAIL_BIT_MASK - Check for CCA fail status.
+ *               0 - The function will not wait for any bits in the system status register (lower 32 bits).
+ *
+ * return None
+ */
+void waitforsysstatus(uint32_t *lo_result, uint32_t *hi_result, uint32_t lo_mask, uint32_t hi_mask)
+{
+    uint32_t lo_result_tmp = 0;
+    uint32_t hi_result_tmp = 0;
+
+    // If a mask has been passed into the function for the system status register (lower 32-bits)
+    if (lo_mask)
+    {
+        while (!((lo_result_tmp = dwt_readsysstatuslo()) & (lo_mask)))
+        {
+            // If a mask value is set for the system status register (higher 32-bits)
+            if (hi_mask)
+            {
+                // If mask value for the system status register (higher 32-bits) is found
+                if ((hi_result_tmp = dwt_readsysstatushi()) & hi_mask)
+                {
+                    break;
+                }
+            }
+        }
+    }
+    // if only a mask value for the system status register (higher 32-bits) is set
+    else if (hi_mask)
+    {
+        while (!((hi_result_tmp = dwt_readsysstatushi()) & (hi_mask))) { };
+    }
+
+    if (lo_result != NULL)
+    {
+        *lo_result = lo_result_tmp;
+    }
+
+    if (hi_result != NULL)
+    {
+        *hi_result = hi_result_tmp;
+    }
+}

--- a/platform/shared_functions.h
+++ b/platform/shared_functions.h
@@ -1,0 +1,221 @@
+/*! ----------------------------------------------------------------------------
+ * @file    shared_functions.h
+ * @brief   Global functions are found here
+ *
+ * @author Decawave
+ *
+ * @copyright SPDX-FileCopyrightText: Copyright (c) 2024 Qorvo US, Inc.
+ *            SPDX-License-Identifier: LicenseRef-QORVO-2
+ *
+ */
+#ifndef _SHARE_FUNC_
+#define _SHARE_FUNC_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Power boost calculation service function defines*/
+#define LUT_1000_200_US_NUM     33 /* Number of frames duration values for which look up table has corresponding dial back in units of 0.1dB*/
+#define LUT_1000_200_US_STEP    25 /* Frame duration step in us between each index in LUT */
+#define LUT_1000_200_US_MIN     200 /* Minimum frame duration characterised by LUT*/
+#define LUT_1000_200_US_MIN_BST 0 /* Boost to apply when a frame is longer or equal to the maximum duration*/
+
+#define LUT_200_70_US_NUM     14 /* Number of frames duration values for which look up table has corresponding dial back in units of 0.1dB*/
+#define LUT_200_70_US_STEP    10 /* Frame duration step in us between each index in LUT */
+#define LUT_200_70_US_MIN     70 /* Minimum frame duration characterised by LUT*/
+#define LUT_200_70_US_MAX_BST 113 /* Total boost to apply when a frame is equal or shorter to the minimum duration*/
+
+#define FRAME_DURATION_REF 1000 /* The reference duration for a frame is 1000us. Longer frame will have 0dB boost.*/
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn calculate_power_boost()
+     *
+     * @brief Calculation the allowed power boost for a frame_duration_us frame relatively to a 1ms frame.
+     *
+     * @param reg: uint16_t duration of frame..
+     *
+     * @return boost: the amount of boost in 0.1dB steps which is allowed when transmitting the frame_dur_us frame
+     *                relatively to a 1ms frame. For example, if the frame duration is 500us, then relatively to 1ms,
+     *                a 3dB boost is allowed, and the function will return 30.
+     */
+    uint8_t calculate_power_boost(uint16_t frame_duration_us);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn check_for_status_errors()
+     *
+     * @brief This function is used to get a value to increase the delay timer by dependent on the current TX preamble length set.
+     *
+     * @param reg: uint32_t value representing the current status register value.
+     * @param errors: pointer to a uint32_t buffer that contains the sum of different errors logged during program operation.
+     *
+     * @return none
+     */
+    void check_for_status_errors(uint32_t reg, uint32_t *errors);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn get_rx_delay_time_txpreamble()
+     *
+     * @brief This function is used to get a value to increase the delay timer by dependent on the current TX preamble length set.
+     *
+     * @param None
+     *
+     * @return delay_time - a uint32_t value indicating the required increase needed to delay the time by.
+     */
+    uint32_t get_rx_delay_time_txpreamble(void);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn get_rx_delay_time_data_rate()
+     *
+     * @brief This function is used to get a value to increase the delay timer by dependent on the current data rate set.
+     *
+     * @param None
+     *
+     * @return delay_time - a uint32_t value indicating the required increase needed to delay the time by.
+     */
+    uint32_t get_rx_delay_time_data_rate(void);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn set_delayed_rx_time()
+     *
+     * @brief This function is used to set the delayed RX time before running dwt_rxenable()
+     *
+     * @param delay - This is a defined delay value (usually POLL_TX_TO_RESP_RX_DLY_UUS)
+     * @param config_options - pointer to dwt_config_t configuration structure that is in use at the time this function
+     *                         is called.
+     *
+     * @return None
+     */
+    void set_delayed_rx_time(uint32_t delay, dwt_config_t *config_options);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn set_resp_rx_timeout()
+     *
+     * @brief This function is used to set the RX timeout value
+     *
+     * @param delay - This is a defined delay value (usually RESP_RX_TIMEOUT_UUS)
+     * @param config_options - pointer to dwt_config_t configuration structure that is in use at the time this function
+     *                         is called.
+     *
+     * @return None
+     */
+    void set_resp_rx_timeout(uint32_t delay, dwt_config_t *config_options);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn resp_msg_get_ts()
+     *
+     * @brief Read a given timestamp value from the response message. In the timestamp fields of the response message, the
+     *        least significant byte is at the lower address.
+     *
+     * @param  ts_field  pointer on the first byte of the timestamp field to get
+     *         ts  timestamp value
+     *
+     * @return none
+     */
+    void resp_msg_get_ts(uint8_t *ts_field, uint32_t *ts);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn get_tx_timestamp_u64()
+     *
+     * @brief Get the TX time-stamp in a 64-bit variable.
+     *        /!\ This function assumes that length of time-stamps is 40 bits, for both TX and RX!
+     *
+     * @param  none
+     *
+     * @return  64-bit value of the read time-stamp.
+     */
+    uint64_t get_tx_timestamp_u64(void);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn get_rx_timestamp_u64()
+     *
+     * @brief Get the RX time-stamp in a 64-bit variable.
+     *        /!\ This function assumes that length of time-stamps is 40 bits, for both TX and RX!
+     *
+     * @param  none
+     *
+     * @return  64-bit value of the read time-stamp.
+     */
+    uint64_t get_rx_timestamp_u64(void);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn final_msg_get_ts()
+     *
+     * @brief Read a given timestamp value from the final message. In the timestamp fields of the final message, the least
+     *        significant byte is at the lower address.
+     *
+     * @param  ts_field  pointer on the first byte of the timestamp field to read
+     *         ts  timestamp value
+     *
+     * @return none
+     */
+    void final_msg_get_ts(const uint8_t *ts_field, uint32_t *ts);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn final_msg_set_ts()
+     *
+     * @brief Fill a given timestamp field in the final message with the given value. In the timestamp fields of the final
+     *        message, the least significant byte is at the lower address.
+     *
+     * @param  ts_field  pointer on the first byte of the timestamp field to fill
+     *         ts  timestamp value
+     *
+     * @return none
+     */
+    void final_msg_set_ts(uint8_t *ts_field, uint64_t ts);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @fn resp_msg_set_ts()
+     *
+     * @brief Fill a given timestamp field in the response message with the given value. In the timestamp fields of the
+     *        response message, the least significant byte is at the lower address.
+     *
+     * @param  ts_field  pointer on the first byte of the timestamp field to fill
+     *         ts  timestamp value
+     *
+     * @return none
+     */
+    void resp_msg_set_ts(uint8_t *ts_field, const uint64_t ts);
+
+    /*! ------------------------------------------------------------------------------------------------------------------
+     * @brief This function will continuously read the system status register until it matches the bits set in the mask
+     *        input parameter. It will then exit the function.
+     *        This is useful to use when waiting on particular events to occurs. For example, the user could wait for a
+     *        good UWB frame to be received and/or no receive errors have occurred.
+     *        The lower 32-bits of the system status register will be read in a while loop. Each iteration of the loop will check if a matching
+     *        mask value for the higher 32-bits of the system status register is set. If the mask value is set in the higher 32-bits of the system
+     *        status register, the function will return that value along with the last recorded value of the lower 32-bits of the system status
+     *        register. Thus, the user should be aware that this function will not wait for high and low mask values to be set in both the low and high
+     *        system status registers. Alternatively, the user can call this function to *only* check the higher or lower system status registers.
+     *
+     * input parameters
+     * @param lo_result - A pointer to a uint32_t that will contain the final value of the system status register (lower 32 bits).
+     *                    Pass in a NULL pointer to ignore returning this value.
+     * @param hi_result - A pointer to a uint32_t that will contain the final value of the system status register (higher 32 bits).
+     *                    Pass in a NULL pointer to ignore returning this value.
+     * @param lo_mask - a uint32 mask value that is used to check for certain bits to be set in the system status register (lower 32 bits).
+     *               Example values to use are as follows:
+     *               DWT_INT_TXFRS_BIT_MASK - Wait for a TX frame to be sent.
+     *               SYS_STATUS_RXFCG_BIT_MASK | SYS_STATUS_ALL_RX_ERR - Wait for frame to be received and no reception errors.
+     *               SYS_STATUS_RXFCG_BIT_MASK | SYS_STATUS_ALL_RX_TO | SYS_STATUS_ALL_RX_ERR - Wait for frame to be received and no receive timeout errors
+     *                                                                                          and no reception errors.
+     *               SYS_STATUS_RXFR_BIT_MASK | SYS_STATUS_ALL_RX_TO | SYS_STATUS_ALL_ND_RX_ERR - Wait for packet to be received and no receive timeout errors
+     *                                                                                            and no reception errors.
+     *                                                                                            These flags are useful when polling for STS Mode 3 (no data)
+     *                                                                                            packets.
+     *               0 - The function will not wait for any bits in the system status register (lower 32 bits).
+     * @param hi_mask - a uint32 mask value that is used to check for certain bits to be set in the system status register (higher 32 bits).
+     *               Example values to use are as follows:
+     *               SYS_STATUS_HI_CCA_FAIL_BIT_MASK - Check for CCA fail status.
+     *               0 - The function will not wait for any bits in the system status register (lower 32 bits).
+     *
+     * return None
+     */
+    void waitforsysstatus(uint32_t *lo_result, uint32_t *hi_result, uint32_t lo_mask, uint32_t hi_mask);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR includes the following updates:
	1.	Dedicated work queue for DW3000 hardware interrupt and async SPI
	•	Replace default system work queue with a dedicated k_work_q for DW3000 hardware interrupts.
	•	Refactor workqueue and ISR initialization for improved thread safety and interrupt reliability.
	•	Migrate SPI read/write operations to use spi_transceive_signal with k_poll for asynchronous handling.
	2.	Add MAC 802.15.4 library from Qorvo SDK
	•	Integrate the MAC 802.15.4 library into the codebase to support IEEE 802.15.4 features.
	3.	Add shared platform functions
	•	Add shared utility functions from the library to the platform directory for reuse.

These changes improve real-time performance and code modularity, and also enable future development for IEEE 802.15.4 support.