### PR TITLE
Add libdeca compatible module name

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+name: decadriver
 build:
   cmake: .
   kconfig: Kconfig


### PR DESCRIPTION
Fix for issue #41. Make this version of the drivers compatible with libdeca by setting it's name to be `decadriver` since libdeca requires a module with that name as a dependency and won't build without it.